### PR TITLE
chore: add libssl dependency to shard.yml

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -3,6 +3,9 @@ version: 1.3.0
 license: MIT
 crystal: ">= 0.36.1"
 
+libraries:
+  libssl: ">= 1.0.2"
+
 development_dependencies:
   ameba:
     github: veelenga/ameba


### PR DESCRIPTION
Adds an [informational only dependency](https://github.com/crystal-lang/shards/blob/master/docs/shard.yml.adoc#optional-attributes) on libssl.

Usage of `OpenSSL::SSL::X509VerifyFlags` is [only available on systems with libssl >= 1.0.2](https://github.com/crystal-lang/crystal/blob/master/src/openssl/lib_crypto.cr#L312-L344).